### PR TITLE
Feature/#47

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ Team2 프론트엔드입니다. Medium을 클론코딩한 [**Wadium**](https://w
 - `/edit` 글 작성 페이지
 - `/story/:storyid` 글 보는 페이지
 - `/search` 검색 페이지
+- `/me/stories` 자신의 글 목록 페이지

--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,7 @@ function App() {
             path={routes.callback.path}
             component={routes.callback.component}
           />
+          <Route path={routes.me.path} component={routes.me.component} />
           <Redirect to={routes.main.path} />
         </Switch>
       </BrowserRouter>

--- a/src/Components/MeStories/ActionButton/index.js
+++ b/src/Components/MeStories/ActionButton/index.js
@@ -1,0 +1,40 @@
+import styled from "styled-components"
+
+const ActionButtonBackground = styled.div``
+
+const ActionButtonWrapper = styled.div``
+
+const Arrow = styled.div``
+
+const ActionButtonMenu = styled.div``
+
+const Link = styled.a``
+
+const Button = styled.button``
+
+const ActionButton = (
+  deleteStory,
+  selectedStoryId,
+  type,
+  closeActionButton
+) => {
+  var word
+  if (type === "drafts") {
+    word = "draft"
+  } else if (type === "public") {
+    word = "story"
+  }
+  return (
+    <ActionButtonBackground onClick={closeActionButton}>
+      <ActionButtonWrapper>
+        <Arrow />
+        <ActionButtonMenu>
+          <Link href={"/edit/" + selectedStoryId}>{"Edit " + word}</Link>
+          <Button onClick={deleteStory}>{"Delete " + word}</Button>
+        </ActionButtonMenu>
+      </ActionButtonWrapper>
+    </ActionButtonBackground>
+  )
+}
+
+export default ActionButton

--- a/src/Components/MeStories/ActionButton/index.js
+++ b/src/Components/MeStories/ActionButton/index.js
@@ -57,8 +57,7 @@ const Button = styled.button`
 `
 
 const ActionButton = ({
-  deleteStory,
-  selectedStoryId,
+  openConfirmModal,
   type,
   closeActionButton,
   isActionButtonOpen,
@@ -79,7 +78,7 @@ const ActionButton = ({
         <Arrow />
         <ActionButtonMenu>
           <Button onClick={startEdit}>{"Edit " + word}</Button>
-          <Button onClick={deleteStory}>{"Delete " + word}</Button>
+          <Button onClick={openConfirmModal}>{"Delete " + word}</Button>
         </ActionButtonMenu>
       </ActionButtonWrapper>
     </ActionButtonBackground>

--- a/src/Components/MeStories/ActionButton/index.js
+++ b/src/Components/MeStories/ActionButton/index.js
@@ -1,22 +1,79 @@
 import styled from "styled-components"
+import Color from "../../../Constants/Color"
 
-const ActionButtonBackground = styled.div``
+const ActionButtonBackground = styled.div`
+  position: absolute;
+  z-index: 500;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: block;
+  display: ${(props) => !props.isActionButtonOpen && "none"};
+`
 
-const ActionButtonWrapper = styled.div``
+const ActionButtonWrapper = styled.div`
+  position: absolute;
+  box-shadow: rgb(230, 230, 230) 0px 1px 4px;
+  border: 1px solid rgb(230, 230, 230);
+  box-sizing: border-box;
+  border-radius: 4px;
+  z-index: 700;
+  background: rgb(255, 255, 255);
+`
 
-const Arrow = styled.div``
+const Arrow = styled.div`
+  z-index: 500;
+  left: 50px;
+  clip: rect(0px, 18px, 14px, -4px);
+  top: -14px;
+  position: absolute;
+  display: block;
+  background: rgb(255, 255, 255);
+  box-shadow: rgb(117, 117, 117) -1px -1px 1px -1px;
+  transform: rotate(45deg) translate(6px, 6px);
+  height: 14px;
+  width: 14px;
+`
 
-const ActionButtonMenu = styled.div``
+const ActionButtonMenu = styled.div`
+  z-index: 600;
+  display: flex;
+  flex-direction: column;
+  padding: 8px 0;
+`
 
-const Link = styled.a``
+const Link = styled.a`
+  padding: 8px 20px;
+  text-decoration: none;
+  cursor: pointer;
+  color: ${Color.gray};
+  line-height: 20px;
+  font-size: 14px;
+  &:hover {
+    color: ${Color.borderBlack};
+  }
+`
 
-const Button = styled.button``
+const Button = styled.button`
+  padding: 8px 20px;
+  border: 0;
+  background: 0;
+  cursor: pointer;
+  color: ${Color.gray};
+  line-height: 20px;
+  font-size: 14px;
+  &:hover {
+    color: ${Color.borderBlack};
+  }
+`
 
 const ActionButton = ({
   deleteStory,
   selectedStoryId,
   type,
   closeActionButton,
+  isActionButtonOpen,
 }) => {
   var word
   if (type === "drafts") {
@@ -25,8 +82,11 @@ const ActionButton = ({
     word = "story"
   }
   return (
-    <ActionButtonBackground onClick={closeActionButton}>
-      <ActionButtonWrapper>
+    <ActionButtonBackground
+      onClick={closeActionButton}
+      isActionButtonOpen={isActionButtonOpen}
+    >
+      <ActionButtonWrapper id="action">
         <Arrow />
         <ActionButtonMenu>
           <Link href={"/edit/" + selectedStoryId}>{"Edit " + word}</Link>

--- a/src/Components/MeStories/ActionButton/index.js
+++ b/src/Components/MeStories/ActionButton/index.js
@@ -12,12 +12,12 @@ const Link = styled.a``
 
 const Button = styled.button``
 
-const ActionButton = (
+const ActionButton = ({
   deleteStory,
   selectedStoryId,
   type,
-  closeActionButton
-) => {
+  closeActionButton,
+}) => {
   var word
   if (type === "drafts") {
     word = "draft"

--- a/src/Components/MeStories/ActionButton/index.js
+++ b/src/Components/MeStories/ActionButton/index.js
@@ -43,18 +43,6 @@ const ActionButtonMenu = styled.div`
   padding: 8px 0;
 `
 
-const Link = styled.a`
-  padding: 8px 20px;
-  text-decoration: none;
-  cursor: pointer;
-  color: ${Color.gray};
-  line-height: 20px;
-  font-size: 14px;
-  &:hover {
-    color: ${Color.borderBlack};
-  }
-`
-
 const Button = styled.button`
   padding: 8px 20px;
   border: 0;
@@ -74,6 +62,7 @@ const ActionButton = ({
   type,
   closeActionButton,
   isActionButtonOpen,
+  startEdit,
 }) => {
   var word
   if (type === "drafts") {
@@ -89,7 +78,7 @@ const ActionButton = ({
       <ActionButtonWrapper id="action">
         <Arrow />
         <ActionButtonMenu>
-          <Link href={"/edit/" + selectedStoryId}>{"Edit " + word}</Link>
+          <Button onClick={startEdit}>{"Edit " + word}</Button>
           <Button onClick={deleteStory}>{"Delete " + word}</Button>
         </ActionButtonMenu>
       </ActionButtonWrapper>

--- a/src/Components/MeStories/ConfirmModal/index.js
+++ b/src/Components/MeStories/ConfirmModal/index.js
@@ -1,0 +1,28 @@
+import styled from "styled-components"
+
+const ModalBackground = styled.div``
+
+const ModalContent = styled.div``
+
+const BigMessage = styled.h1``
+
+const Message = styled.h4``
+
+const Button = styled.button``
+
+const RedButton = styled.button``
+
+const ConfirmModal = ({ deleteStory, hideConfirmModal }) => {
+  return (
+    <ModalBackground>
+      <ModalContent>
+        <BigMessage>Delete story</BigMessage>
+        <Message>Are you sure you want to delete this story?</Message>
+        <Button onClick={hideConfirmModal}>Cancel</Button>
+        <RedButton onClick={deleteStory}>Delete</RedButton>
+      </ModalContent>
+    </ModalBackground>
+  )
+}
+
+export default ConfirmModal

--- a/src/Components/MeStories/ConfirmModal/index.js
+++ b/src/Components/MeStories/ConfirmModal/index.js
@@ -1,16 +1,99 @@
 import styled from "styled-components"
+import Color from "../../../Constants/Color"
 
-const ModalBackground = styled.div``
+const ModalBackground = styled.div`
+  background-color: rgba(255, 255, 255, 0.95);
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 800;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
 
-const ModalContent = styled.div``
+const ModalContent = styled.div`
+  margin-bottom: auto;
+  margin-top: auto;
+  padding: 64px;
+  width: 900px;
+  background: white;
+  box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 10px;
+  min-height: 550px;
+  box-sizing: border-box;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
 
-const BigMessage = styled.h1``
+  @media (max-width: 904px) {
+    width: 720px;
+  }
 
-const Message = styled.h4``
+  @media (max-width: 728px) {
+    width: 540px;
+  }
 
-const Button = styled.button``
+  @media (max-width: 552px) {
+    width: 320px;
+  }
+`
 
-const RedButton = styled.button``
+const BigMessage = styled.h1`
+  margin: 0;
+  line-height: 36px;
+  font-size: 32px;
+  color: ${Color.borderBlack};
+  font-weight: 700;
+  font-family: "Noto Sans";
+`
+
+const Message = styled.h4`
+  margin: 0;
+  padding-top: 6px;
+  padding-bottom: 36px;
+  line-height: 24px;
+  font-size: 18px;
+  color: ${Color.gray};
+  font-weight: 400;
+  font-family: "Noto Sans";
+`
+
+const ButtonWrapper = styled.div``
+
+const Button = styled.button`
+  padding: 9px 16px 7px;
+  box-sizing: border-box;
+  border: 1px solid ${Color.gray};
+  background: 0;
+  color: ${Color.borderBlack};
+  line-height: 20px;
+  font-size: 15px;
+  font-family: "Noto Sans";
+  border-radius: 4px;
+  cursor: pointer;
+`
+
+const RedButton = styled.button`
+  margin-left: 8px;
+  padding: 9px 16px 7px;
+  box-sizing: border-box;
+  border: 1px solid ${Color.red};
+  background: ${Color.red};
+  color: white;
+  line-height: 20px;
+  font-size: 15px;
+  font-family: "Noto Sans";
+  border-radius: 4px;
+  cursor: pointer;
+  &:hover {
+    border-color: ${Color.hoverRed};
+    background: ${Color.hoverRed};
+  }
+`
 
 const ConfirmModal = ({ deleteStory, hideConfirmModal }) => {
   return (
@@ -18,8 +101,10 @@ const ConfirmModal = ({ deleteStory, hideConfirmModal }) => {
       <ModalContent>
         <BigMessage>Delete story</BigMessage>
         <Message>Are you sure you want to delete this story?</Message>
-        <Button onClick={hideConfirmModal}>Cancel</Button>
-        <RedButton onClick={deleteStory}>Delete</RedButton>
+        <ButtonWrapper>
+          <Button onClick={hideConfirmModal}>Cancel</Button>
+          <RedButton onClick={deleteStory}>Delete</RedButton>
+        </ButtonWrapper>
       </ModalContent>
     </ModalBackground>
   )

--- a/src/Components/MeStories/Header/HeaderRight.js
+++ b/src/Components/MeStories/Header/HeaderRight.js
@@ -3,7 +3,10 @@ import UserProfile from "../../MainLogin/Header/UserProfile"
 import Search from "../../MainLogin/Header/Search"
 import default_profile_image from "../../../Images/default_profile_image.png"
 
-const Wrapper = styled.div``
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+`
 
 const HeaderRight = ({
   user,

--- a/src/Components/MeStories/Header/HeaderRight.js
+++ b/src/Components/MeStories/Header/HeaderRight.js
@@ -1,0 +1,33 @@
+import styled from "styled-components"
+import UserProfile from "../../MainLogin/Header/UserProfile"
+import Search from "../../MainLogin/Header/Search"
+import default_profile_image from "../../../Images/default_profile_image.png"
+
+const Wrapper = styled.div``
+
+const HeaderRight = ({
+  user,
+  openDropdown,
+  isSearchboxOpen,
+  onClickSearchButton,
+  onChangeSearchbox,
+  search,
+}) => {
+  let { profileImage } = user
+  if (profileImage === "" || profileImage === undefined) {
+    profileImage = default_profile_image
+  }
+  return (
+    <Wrapper>
+      <Search
+        isSearchboxOpen={isSearchboxOpen}
+        onClickSearchButton={onClickSearchButton}
+        onChangeSearchbox={onChangeSearchbox}
+        search={search}
+      />
+      <UserProfile profileImage={profileImage} openDropdown={openDropdown} />
+    </Wrapper>
+  )
+}
+
+export default HeaderRight

--- a/src/Components/MeStories/Header/index.js
+++ b/src/Components/MeStories/Header/index.js
@@ -8,6 +8,8 @@ const HeaderShadow = styled.div`
   width: 100%;
   height: 65px;
   box-shadow: 0 4px 12px 0 rgba(0, 0, 0, 0.05) !important;
+  display: flex;
+  justify-content: center;
   @media (max-width: 767px) {
     height: 56px;
   }
@@ -15,6 +17,7 @@ const HeaderShadow = styled.div`
 
 const HeaderStyle = styled.div`
   max-width: 1192px;
+  width: 100%;
   margin: 0 64px;
   height: 100%;
   display: flex;

--- a/src/Components/MeStories/Header/index.js
+++ b/src/Components/MeStories/Header/index.js
@@ -14,13 +14,25 @@ const HeaderShadow = styled.div`
 `
 
 const HeaderStyle = styled.div`
-  max-width: 1032px;
-  padding: 0 20px;
-  margin: 0 auto;
+  max-width: 1192px;
+  margin: 0 64px;
   height: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  @media (max-width: 903.98px) {
+    margin-right: 48px;
+    margin-left: 48px;
+  }
+
+  @media (max-width: 767px) {
+    margin-bottom: 24px;
+  }
+
+  @media (max-width: 552px) {
+    margin-right: 24px;
+    margin-left: 24px;
+  }
 `
 
 const Header = (props) => {

--- a/src/Components/MeStories/Header/index.js
+++ b/src/Components/MeStories/Header/index.js
@@ -1,0 +1,40 @@
+import styled from "styled-components"
+import Logo from "../../Search/Header/Logo"
+import SmallLogo from "../../Search/Header/SmallLogo"
+import HeaderRight from "./HeaderRight"
+
+const HeaderShadow = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 65px;
+  box-shadow: 0 4px 12px 0 rgba(0, 0, 0, 0.05) !important;
+  @media (max-width: 767px) {
+    height: 56px;
+  }
+`
+
+const HeaderStyle = styled.div`
+  max-width: 1032px;
+  padding: 0 20px;
+  margin: 0 auto;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`
+
+const Header = (props) => {
+  return (
+    <HeaderShadow>
+      <HeaderStyle>
+        <a href="/main">
+          <Logo />
+          <SmallLogo />
+        </a>
+        <HeaderRight {...props} />
+      </HeaderStyle>
+    </HeaderShadow>
+  )
+}
+
+export default Header

--- a/src/Components/MeStories/Main/MainHeader.js
+++ b/src/Components/MeStories/Main/MainHeader.js
@@ -1,7 +1,43 @@
 import styled from "styled-components"
+import Color from "../../../Constants/Color"
+
+const HeaderWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  padding-bottom: 40px;
+`
+
+const HeaderMessage = styled.h1`
+  line-height: 52px;
+  font-size: 42px;
+  font-family: "Noto Sans";
+  color: ${Color.borderBlack};
+  margin: 0;
+`
+
+const HeaderLink = styled.a`
+  text-decoration: none;
+  border: 1px solid ${Color.green};
+  color: ${Color.green};
+  padding: 9px 16px 7px;
+  font-family: "Noto Sans";
+  border-radius: 4px;
+
+  &:hover {
+    border-color: ${Color.hoverGreen};
+    color: ${Color.hoverGreen};
+  }
+`
 
 const MainHeader = () => {
-  return <div>header</div>
+  return (
+    <HeaderWrapper>
+      <HeaderMessage>Your stories</HeaderMessage>
+      <HeaderLink href="/edit">Write a story</HeaderLink>
+    </HeaderWrapper>
+  )
 }
 
 export default MainHeader

--- a/src/Components/MeStories/Main/MainHeader.js
+++ b/src/Components/MeStories/Main/MainHeader.js
@@ -1,0 +1,7 @@
+import styled from "styled-components"
+
+const MainHeader = () => {
+  return <div>header</div>
+}
+
+export default MainHeader

--- a/src/Components/MeStories/Main/MainList.js
+++ b/src/Components/MeStories/Main/MainList.js
@@ -1,17 +1,109 @@
 import styled from "styled-components"
+import Color from "../../../Constants/Color"
 
-const MainList = ({ stories, type }) => {
+const MainListWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+const StoryBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 20px 0;
+  border-bottom: 1px solid rgb(230, 230, 230);
+`
+
+const Title = styled.a`
+  -webkit-line-clamp: 2;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  max-height: 40px;
+  font-weight: 700;
+  margin: 0;
+  color: ${Color.borderBlack};
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 20px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`
+
+const Subtitle = styled.a`
+  -webkit-line-clamp: 2;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  max-height: 40px;
+  font-weight: 400;
+  margin: 0;
+  color: ${Color.gray};
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 20px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 4px;
+`
+
+const LastLine = styled.div`
+  display: flex;
+`
+
+const Time = styled.p`
+  margin: 0;
+  margin-top: 8px;
+  color: ${Color.gray};
+  font-size: 14px;
+  line-height: 20px;
+`
+
+const ActionButton = styled.button`
+  border: 0;
+  margin: 0;
+  margin-left: 8px;
+  margin-top: 6px;
+  background: 0;
+  padding: 0;
+  height: 21px;
+  cursor: pointer;
+`
+
+const SvgStyle = styled.svg`
+  fill: ${Color.gray};
+  width: 21px;
+  height: 21px;
+  vertical-align: middle;
+`
+
+const MainList = ({ stories, type, openActionButton }) => {
+  var link
+  if (type === "public") {
+    link = "/story/"
+  } else if (type === "drafts") {
+    link = "/edit/"
+  }
   return (
-    <div>
+    <MainListWrapper>
       {stories.map((story, index) => {
         return (
-          <div key={index}>
-            <p>{story.title}</p>
-            <p>{story.subtitle}</p>
-          </div>
+          <StoryBlock key={index}>
+            <Title href={link + story.id}>{story.title}</Title>
+            <Subtitle href={link + story.id}>{story.subtitle}</Subtitle>
+            <LastLine>
+              <Time>{story.updated_at}</Time>
+              <ActionButton
+                onClick={() => {
+                  openActionButton(story.id)
+                }}
+              >
+                <SvgStyle>
+                  <path d="M4 7.33L10.03 14l.5.55.5-.55 5.96-6.6-.98-.9-5.98 6.6h1L4.98 6.45z"></path>
+                </SvgStyle>
+              </ActionButton>
+            </LastLine>
+          </StoryBlock>
         )
       })}
-    </div>
+    </MainListWrapper>
   )
 }
 

--- a/src/Components/MeStories/Main/MainList.js
+++ b/src/Components/MeStories/Main/MainList.js
@@ -1,5 +1,6 @@
 import styled from "styled-components"
 import Color from "../../../Constants/Color"
+import getTimeLeft from "../../../Pages/Me/Functions/getTimeLeft"
 
 const MainListWrapper = styled.div`
   display: flex;
@@ -88,7 +89,7 @@ const MainList = ({ stories, type, openActionButton }) => {
             <Title href={link + story.id}>{story.title}</Title>
             <Subtitle href={link + story.id}>{story.subtitle}</Subtitle>
             <LastLine>
-              <Time>{story.updated_at}</Time>
+              <Time>{getTimeLeft(story.updated_at)}</Time>
               <ActionButton
                 onClick={(event) => {
                   openActionButton(event, story.id)

--- a/src/Components/MeStories/Main/MainList.js
+++ b/src/Components/MeStories/Main/MainList.js
@@ -1,0 +1,18 @@
+import styled from "styled-components"
+
+const MainList = ({ stories, type }) => {
+  return (
+    <div>
+      {stories.map((story, index) => {
+        return (
+          <div key={index}>
+            <p>{story.title}</p>
+            <p>{story.subtitle}</p>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default MainList

--- a/src/Components/MeStories/Main/MainList.js
+++ b/src/Components/MeStories/Main/MainList.js
@@ -7,8 +7,7 @@ const MainListWrapper = styled.div`
 `
 
 const StoryBlock = styled.div`
-  display: flex;
-  flex-direction: column;
+  display: block;
   padding: 20px 0;
   border-bottom: 1px solid rgb(230, 230, 230);
 `
@@ -91,8 +90,8 @@ const MainList = ({ stories, type, openActionButton }) => {
             <LastLine>
               <Time>{story.updated_at}</Time>
               <ActionButton
-                onClick={() => {
-                  openActionButton(story.id)
+                onClick={(event) => {
+                  openActionButton(event, story.id)
                 }}
               >
                 <SvgStyle>

--- a/src/Components/MeStories/Main/MainTab.js
+++ b/src/Components/MeStories/Main/MainTab.js
@@ -33,7 +33,6 @@ const Link = styled.a`
 `
 
 const MainTab = ({ type }) => {
-  console.log(type === "public")
   return (
     <MainTabWrapper>
       <LinkWrapper>

--- a/src/Components/MeStories/Main/MainTab.js
+++ b/src/Components/MeStories/Main/MainTab.js
@@ -1,0 +1,7 @@
+import styled from "styled-components"
+
+const MainTab = () => {
+  return <div>tabs</div>
+}
+
+export default MainTab

--- a/src/Components/MeStories/Main/MainTab.js
+++ b/src/Components/MeStories/Main/MainTab.js
@@ -1,5 +1,4 @@
 import styled from "styled-components"
-import Color from "../../../Constants/Color"
 
 const MainTabWrapper = styled.div`
   border-bottom: 1px solid rgba(230, 230, 230);

--- a/src/Components/MeStories/Main/MainTab.js
+++ b/src/Components/MeStories/Main/MainTab.js
@@ -43,7 +43,7 @@ const MainTab = ({ type }) => {
         </LinkBox>
         <LinkBox active={type === "public"}>
           <Link href="/me/stories/public" active={type === "public"}>
-            Publised
+            Published
           </Link>
         </LinkBox>
       </LinkWrapper>

--- a/src/Components/MeStories/Main/MainTab.js
+++ b/src/Components/MeStories/Main/MainTab.js
@@ -1,7 +1,56 @@
 import styled from "styled-components"
+import Color from "../../../Constants/Color"
 
-const MainTab = () => {
-  return <div>tabs</div>
+const MainTabWrapper = styled.div`
+  border-bottom: 1px solid rgba(230, 230, 230);
+  display: block;
+  box-sizing: border-box;
+`
+
+const LinkWrapper = styled.ul`
+  box-sizing: inherit;
+  margin: 0;
+  margin-bottom: -1px;
+  padding: 0;
+  list-style: none;
+  display: flex;
+`
+
+const LinkBox = styled.li`
+  outline: none;
+  margin-right: 20px;
+  box-sizing: inherit;
+  padding-bottom: 8px;
+  border-bottom: ${(props) => props.active && "1px solid rgb(117, 117, 117)"};
+`
+
+const Link = styled.a`
+  text-decoration: none;
+  color: ${(props) =>
+    (props.active && "rgb(41, 41, 41)") || "rgb(117, 117, 117)"};
+  line-height: 20px;
+  font-size: 15px;
+  font-family: "Noto Sans";
+`
+
+const MainTab = ({ type }) => {
+  console.log(type === "public")
+  return (
+    <MainTabWrapper>
+      <LinkWrapper>
+        <LinkBox active={type === "drafts"}>
+          <Link href="/me/stories/drafts" active={type === "drafts"}>
+            Drafts
+          </Link>
+        </LinkBox>
+        <LinkBox active={type === "public"}>
+          <Link href="/me/stories/public" active={type === "public"}>
+            Publised
+          </Link>
+        </LinkBox>
+      </LinkWrapper>
+    </MainTabWrapper>
+  )
 }
 
 export default MainTab

--- a/src/Components/MeStories/Main/index.js
+++ b/src/Components/MeStories/Main/index.js
@@ -38,12 +38,16 @@ const MainWrapper = styled.div`
   }
 `
 
-const Main = ({ stories, type, deleteStory }) => {
+const Main = ({ stories, type, openActionButton }) => {
   return (
     <MainWrapper>
       <MainHeader />
       <MainTab type={type} />
-      <MainList stories={stories} type={type} deleteStory={deleteStory} />
+      <MainList
+        stories={stories}
+        type={type}
+        openActionButton={openActionButton}
+      />
     </MainWrapper>
   )
 }

--- a/src/Components/MeStories/Main/index.js
+++ b/src/Components/MeStories/Main/index.js
@@ -1,0 +1,26 @@
+import styled from "styled-components"
+import MainHeader from "./MainHeader"
+import MainTab from "./MainTab"
+import MainList from "./MainList"
+
+const MainWrapper = styled.div`
+  margin-top: 129px;
+  display: flex;
+  flex-direction: column;
+
+  @media (max-width: 767px) {
+    margin-top: 80px;
+  }
+`
+
+const Main = ({ stories, type, deleteStory }) => {
+  return (
+    <MainWrapper>
+      <MainHeader />
+      <MainTab type={type} />
+      <MainList stories={stories} type={type} deleteStory={deleteStory} />
+    </MainWrapper>
+  )
+}
+
+export default Main

--- a/src/Components/MeStories/Main/index.js
+++ b/src/Components/MeStories/Main/index.js
@@ -5,11 +5,36 @@ import MainList from "./MainList"
 
 const MainWrapper = styled.div`
   margin-top: 129px;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: 64px;
+  padding-left: 64px;
+  padding-bottom: 64px;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 1320px;
   display: flex;
   flex-direction: column;
 
+  @media (max-width: 1080px) {
+    max-width: 1080px;
+  }
+
+  @media (max-width: 903.98px) {
+    max-width: 904px;
+    padding-right: 48px;
+    padding-left: 48px;
+  }
+
   @media (max-width: 767px) {
     margin-top: 80px;
+    padding-bottom: 24px;
+  }
+
+  @media (max-width: 552px) {
+    max-width: 552px;
+    padding-right: 24px;
+    padding-left: 24px;
   }
 `
 

--- a/src/Components/MeStories/index.js
+++ b/src/Components/MeStories/index.js
@@ -3,6 +3,7 @@ import Header from "./Header"
 import Main from "./Main"
 import ActionButton from "./ActionButton"
 import UserDropdown from "../MainLogin/UserDropdown"
+import ConfirmModal from "./ConfirmModal"
 
 const MeStoriesStyle = styled.div`
   position: relative;
@@ -28,6 +29,9 @@ const MeStories = ({
   deleteStory,
   selectedStoryId,
   startEdit,
+  showConfirmModal,
+  openConfirmModal,
+  hideConfirmModal,
 }) => {
   return (
     <MeStoriesStyle>
@@ -42,7 +46,7 @@ const MeStories = ({
       <Main stories={stories} type={type} openActionButton={openActionButton} />
       <ActionButton
         closeActionButton={closeActionButton}
-        deleteStory={deleteStory}
+        openConfirmModal={openConfirmModal}
         selectedStoryId={selectedStoryId}
         type={type}
         isActionButtonOpen={isActionButtonOpen}
@@ -53,6 +57,12 @@ const MeStories = ({
           user={user}
           signOut={signOut}
           hideDropdown={hideDropdown}
+        />
+      )}
+      {showConfirmModal && (
+        <ConfirmModal
+          deleteStory={deleteStory}
+          hideConfirmModal={hideConfirmModal}
         />
       )}
     </MeStoriesStyle>

--- a/src/Components/MeStories/index.js
+++ b/src/Components/MeStories/index.js
@@ -1,5 +1,14 @@
-const MeStories = () => {
-  return <div>hi</div>
+import styled from "styled-components"
+import Header from "./Header"
+
+const MeStoriesStyle = styled.div``
+
+const MeStories = ({ user, openDropdown }) => {
+  return (
+    <MeStoriesStyle>
+      <Header user={user} openDropdown={openDropdown} />
+    </MeStoriesStyle>
+  )
 }
 
 export default MeStories

--- a/src/Components/MeStories/index.js
+++ b/src/Components/MeStories/index.js
@@ -1,6 +1,7 @@
 import styled from "styled-components"
 import Header from "./Header"
 import Main from "./Main"
+import ActionButton from "./ActionButton"
 import UserDropdown from "../MainLogin/UserDropdown"
 
 const MeStoriesStyle = styled.div`
@@ -21,6 +22,11 @@ const MeStories = ({
   search,
   stories,
   type,
+  openActionButton,
+  closeActionButton,
+  isActionButtonOpen,
+  deleteStory,
+  selectedStoryId,
 }) => {
   return (
     <MeStoriesStyle>
@@ -32,7 +38,15 @@ const MeStories = ({
         onChangeSearchbox={onChangeSearchbox}
         search={search}
       />
-      <Main stories={stories} type={type} />
+      <Main stories={stories} type={type} openActionButton={openActionButton} />
+      {isActionButtonOpen && (
+        <ActionButton
+          closeActionButton={closeActionButton}
+          deleteStory={deleteStory}
+          selectedStoryId={selectedStoryId}
+          type={type}
+        />
+      )}
       {isDropdownOpened && (
         <UserDropdown
           user={user}

--- a/src/Components/MeStories/index.js
+++ b/src/Components/MeStories/index.js
@@ -1,8 +1,13 @@
 import styled from "styled-components"
 import Header from "./Header"
+import Main from "./Main"
 import UserDropdown from "../MainLogin/UserDropdown"
 
-const MeStoriesStyle = styled.div``
+const MeStoriesStyle = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+`
 
 const MeStories = ({
   user,
@@ -14,6 +19,7 @@ const MeStories = ({
   onClickSearchButton,
   onChangeSearchbox,
   search,
+  stories,
 }) => {
   return (
     <MeStoriesStyle>
@@ -25,6 +31,7 @@ const MeStories = ({
         onChangeSearchbox={onChangeSearchbox}
         search={search}
       />
+      <Main stories={stories} />
       {isDropdownOpened && (
         <UserDropdown
           user={user}

--- a/src/Components/MeStories/index.js
+++ b/src/Components/MeStories/index.js
@@ -39,14 +39,13 @@ const MeStories = ({
         search={search}
       />
       <Main stories={stories} type={type} openActionButton={openActionButton} />
-      {isActionButtonOpen && (
-        <ActionButton
-          closeActionButton={closeActionButton}
-          deleteStory={deleteStory}
-          selectedStoryId={selectedStoryId}
-          type={type}
-        />
-      )}
+      <ActionButton
+        closeActionButton={closeActionButton}
+        deleteStory={deleteStory}
+        selectedStoryId={selectedStoryId}
+        type={type}
+        isActionButtonOpen={isActionButtonOpen}
+      />
       {isDropdownOpened && (
         <UserDropdown
           user={user}

--- a/src/Components/MeStories/index.js
+++ b/src/Components/MeStories/index.js
@@ -27,6 +27,7 @@ const MeStories = ({
   isActionButtonOpen,
   deleteStory,
   selectedStoryId,
+  startEdit,
 }) => {
   return (
     <MeStoriesStyle>
@@ -45,6 +46,7 @@ const MeStories = ({
         selectedStoryId={selectedStoryId}
         type={type}
         isActionButtonOpen={isActionButtonOpen}
+        startEdit={startEdit}
       />
       {isDropdownOpened && (
         <UserDropdown

--- a/src/Components/MeStories/index.js
+++ b/src/Components/MeStories/index.js
@@ -20,6 +20,7 @@ const MeStories = ({
   onChangeSearchbox,
   search,
   stories,
+  type,
 }) => {
   return (
     <MeStoriesStyle>
@@ -31,7 +32,7 @@ const MeStories = ({
         onChangeSearchbox={onChangeSearchbox}
         search={search}
       />
-      <Main stories={stories} />
+      <Main stories={stories} type={type} />
       {isDropdownOpened && (
         <UserDropdown
           user={user}

--- a/src/Components/MeStories/index.js
+++ b/src/Components/MeStories/index.js
@@ -1,0 +1,5 @@
+const MeStories = () => {
+  return <div>hi</div>
+}
+
+export default MeStories

--- a/src/Components/MeStories/index.js
+++ b/src/Components/MeStories/index.js
@@ -1,12 +1,37 @@
 import styled from "styled-components"
 import Header from "./Header"
+import UserDropdown from "../MainLogin/UserDropdown"
 
 const MeStoriesStyle = styled.div``
 
-const MeStories = ({ user, openDropdown }) => {
+const MeStories = ({
+  user,
+  isDropdownOpened,
+  openDropdown,
+  hideDropdown,
+  signOut,
+  isSearchboxOpen,
+  onClickSearchButton,
+  onChangeSearchbox,
+  search,
+}) => {
   return (
     <MeStoriesStyle>
-      <Header user={user} openDropdown={openDropdown} />
+      <Header
+        user={user}
+        openDropdown={openDropdown}
+        isSearchboxOpen={isSearchboxOpen}
+        onClickSearchButton={onClickSearchButton}
+        onChangeSearchbox={onChangeSearchbox}
+        search={search}
+      />
+      {isDropdownOpened && (
+        <UserDropdown
+          user={user}
+          signOut={signOut}
+          hideDropdown={hideDropdown}
+        />
+      )}
     </MeStoriesStyle>
   )
 }

--- a/src/Constants/Color.js
+++ b/src/Constants/Color.js
@@ -13,6 +13,8 @@ const Color = {
   Footerblack: `rgba(0, 0, 0, 0.9)`,
   mobilegray: `rgba(255, 255, 255, 0.7)`,
   placeholder: `rgba(245, 245, 245, 1)`,
+  red: `rgb(201, 74, 74)`,
+  hoverRed: `rgb(180, 44, 44)`,
 }
 
 export default Color

--- a/src/Pages/Edit/EditLogin.js
+++ b/src/Pages/Edit/EditLogin.js
@@ -1,7 +1,7 @@
 import Edit from "../../Components/Edit"
 import { useState, useEffect, useRef } from "react"
 import { useCookies } from "react-cookie"
-import { useHistory } from "react-router-dom"
+import { useHistory, useLocation } from "react-router-dom"
 import SaveStatusConstants from "../../Constants/SaveStatusConstants"
 import findTitle from "./Functions/findTitle"
 import createNewContent from "./Functions/createNewContent"
@@ -18,13 +18,10 @@ import publish from "./Functions/publish"
 import preserveCaret from "./Functions/preserveCaret"
 import addDivider from "./Functions/addDivider"
 import createImage from "./Functions/createImage"
+import getStory from "./Functions/getStory"
 
 const EditLoginPage = ({ token }) => {
   const [user, setUser] = useState({})
-
-  useEffect(() => {
-    getCurrentUser(token, setUser)
-  }, [token])
 
   const [story, setStory] = useState([
     [{ type: "paragraph", detail: { content: "", emphasizing: "largest" } }],
@@ -32,10 +29,18 @@ const EditLoginPage = ({ token }) => {
 
   const removeCookie = useCookies(["auth"])[2]
   const history = useHistory()
+  const storyId = useLocation().pathname.split("/")[2]
+
+  useEffect(() => {
+    getCurrentUser(token, setUser)
+    if (storyId !== "" && storyId !== undefined) {
+      getStory(storyId, setStory)
+    }
+  }, [token, storyId])
 
   // 글 저장 관련
   const [saveStatus, setSaveStatus] = useState(SaveStatusConstants.INIT)
-  const id = useRef(-1)
+  const id = useRef(storyId)
 
   var typingTimer
 

--- a/src/Pages/Edit/EditLogin.js
+++ b/src/Pages/Edit/EditLogin.js
@@ -26,6 +26,7 @@ const EditLoginPage = ({ token }) => {
   const [story, setStory] = useState([
     [{ type: "paragraph", detail: { content: "", emphasizing: "largest" } }],
   ])
+  const id = useRef(-1)
 
   const removeCookie = useCookies(["auth"])[2]
   const history = useHistory()
@@ -35,12 +36,12 @@ const EditLoginPage = ({ token }) => {
     getCurrentUser(token, setUser)
     if (storyId !== "" && storyId !== undefined) {
       getStory(storyId, setStory)
+      id.current = storyId
     }
   }, [token, storyId])
 
   // 글 저장 관련
   const [saveStatus, setSaveStatus] = useState(SaveStatusConstants.INIT)
-  const id = useRef(storyId)
 
   var typingTimer
 

--- a/src/Pages/Edit/Functions/getStory.js
+++ b/src/Pages/Edit/Functions/getStory.js
@@ -1,0 +1,14 @@
+import { getStoryById } from "../../../api"
+
+const getStory = async (id, setStory) => {
+  try {
+    const response = await getStoryById(id)
+    setStory(response.data.body)
+    return response
+  } catch (error) {
+    console.log(error)
+    return error
+  }
+}
+
+export default getStory

--- a/src/Pages/Me/Functions/deleteStory.js
+++ b/src/Pages/Me/Functions/deleteStory.js
@@ -1,0 +1,12 @@
+import { deleteStoryStoryId } from "../../../api"
+
+const deleteStory = async (token, selectedStoryId) => {
+  try {
+    const response = await deleteStoryStoryId(token, selectedStoryId)
+    return response
+  } catch (error) {
+    console.log(error)
+  }
+}
+
+export default deleteStory

--- a/src/Pages/Me/Functions/deleteStory.js
+++ b/src/Pages/Me/Functions/deleteStory.js
@@ -3,6 +3,7 @@ import { deleteStoryStoryId } from "../../../api"
 const deleteStory = async (token, selectedStoryId) => {
   try {
     const response = await deleteStoryStoryId(token, selectedStoryId)
+    window.location.reload()
     return response
   } catch (error) {
     console.log(error)

--- a/src/Pages/Me/Functions/fetchStories.js
+++ b/src/Pages/Me/Functions/fetchStories.js
@@ -4,7 +4,9 @@ const fetchStories = async (token, type, setStories, setIsEnd, page = 1) => {
   const typeBool = type === "public"
   try {
     const response = await getUserMeStory(token, typeBool, page)
-    setStories(response.data.stories)
+    setStories((stories) => {
+      return [...stories, ...response.data.stories]
+    })
     if (response.data.next === null) {
       setIsEnd(true)
     }

--- a/src/Pages/Me/Functions/fetchStories.js
+++ b/src/Pages/Me/Functions/fetchStories.js
@@ -1,0 +1,16 @@
+import { getUserMeStory } from "../../../api"
+
+const fetchStories = async (token, type, setStories, setIsEnd, page = 1) => {
+  const typeBool = type === "public"
+  try {
+    const response = await getUserMeStory(token, typeBool, page)
+    setStories(response.data.stories)
+    if (response.data.next === null) {
+      setIsEnd(true)
+    }
+  } catch (error) {
+    console.log(error)
+  }
+}
+
+export default fetchStories

--- a/src/Pages/Me/Functions/getTimeLeft.js
+++ b/src/Pages/Me/Functions/getTimeLeft.js
@@ -4,7 +4,6 @@ const getTimeLeft = (editTime, type) => {
   if (type === "public") {
     m = "Published about "
   }
-  console.log(editTime)
   const currentDate = new Date()
   const [date, time] = editTime.split("T")
   const [year, month, day] = date.split("-").map((element) => parseInt(element))
@@ -12,7 +11,6 @@ const getTimeLeft = (editTime, type) => {
     .slice(0, 8)
     .split(":")
     .map((element) => parseInt(element))
-  console.log(time)
 
   const yearDiff = currentDate.getUTCFullYear() - year
   if (yearDiff > 0) {

--- a/src/Pages/Me/Functions/getTimeLeft.js
+++ b/src/Pages/Me/Functions/getTimeLeft.js
@@ -1,0 +1,60 @@
+const getTimeLeft = (editTime, type) => {
+  //2021-01-06T08:58:13.908146Z
+  var m = "Last edited about "
+  if (type === "public") {
+    m = "Published about "
+  }
+  console.log(editTime)
+  const currentDate = new Date()
+  const [date, time] = editTime.split("T")
+  const [year, month, day] = date.split("-").map((element) => parseInt(element))
+  const [hour, minute] = time
+    .slice(0, 8)
+    .split(":")
+    .map((element) => parseInt(element))
+  console.log(time)
+
+  const yearDiff = currentDate.getUTCFullYear() - year
+  if (yearDiff > 0) {
+    if (yearDiff === 1) {
+      return m + yearDiff + " year ago"
+    }
+    return m + yearDiff + " years ago"
+  }
+
+  const monthDiff = currentDate.getUTCMonth() - month
+  if (monthDiff > 0) {
+    if (monthDiff === 1) {
+      return m + monthDiff + " month ago"
+    }
+    return m + monthDiff + " months ago"
+  }
+
+  const dayDiff = currentDate.getUTCDay() - day
+  if (dayDiff > 0) {
+    if (dayDiff === 1) {
+      return m + dayDiff + " day ago"
+    }
+    return m + dayDiff + " days ago"
+  }
+
+  const hourDiff = currentDate.getUTCHours() - hour
+  if (hourDiff > 0) {
+    if (hourDiff === 1) {
+      return m + hourDiff + " hour ago"
+    }
+    return m + hourDiff + " hours ago"
+  }
+
+  const minDiff = currentDate.getUTCMinutes() - minute
+  if (minDiff > 0) {
+    if (minDiff === 1) {
+      return m + minDiff + " minute ago"
+    }
+    return m + minDiff + " minutes ago"
+  }
+
+  return "Edited less than a minute ago"
+}
+
+export default getTimeLeft

--- a/src/Pages/Me/Functions/openActionButton.js
+++ b/src/Pages/Me/Functions/openActionButton.js
@@ -1,7 +1,15 @@
-const openActionButton = (setIsActionButtonOpen, setSelectedStoryId, id) => {
-  console.log(id)
+const openActionButton = (
+  event,
+  setIsActionButtonOpen,
+  setSelectedStoryId,
+  id
+) => {
   setSelectedStoryId(id)
   setIsActionButtonOpen(true)
+  const menu = document.getElementById("action")
+  const rect = event.target.getBoundingClientRect()
+  menu.style.top = rect.top + window.scrollY + 25 + "px"
+  menu.style.left = rect.left - 47 + window.scrollX + "px"
 }
 
 export default openActionButton

--- a/src/Pages/Me/Functions/openActionButton.js
+++ b/src/Pages/Me/Functions/openActionButton.js
@@ -1,0 +1,6 @@
+const openActionButton = (setIsActionButtonOpen, setSelectedStoryId, id) => {
+  setSelectedStoryId(id)
+  setIsActionButtonOpen(true)
+}
+
+export default openActionButton

--- a/src/Pages/Me/Functions/openActionButton.js
+++ b/src/Pages/Me/Functions/openActionButton.js
@@ -1,4 +1,5 @@
 const openActionButton = (setIsActionButtonOpen, setSelectedStoryId, id) => {
+  console.log(id)
   setSelectedStoryId(id)
   setIsActionButtonOpen(true)
 }

--- a/src/Pages/Me/Functions/startEdit.js
+++ b/src/Pages/Me/Functions/startEdit.js
@@ -1,0 +1,23 @@
+import { getStoryById, postStory } from "../../../api"
+
+const startEdit = async (token, type, id, history) => {
+  try {
+    let newId = id
+    if (type === "public") {
+      let response = await getStoryById(id)
+      const { title, subtitle, body, featured_image } = response.data
+      response = await postStory(token, {
+        title,
+        subtitle,
+        body,
+        featured_image,
+      })
+      newId = response.data.id
+    }
+    history.push("/edit/" + newId)
+  } catch (error) {
+    console.log(error)
+  }
+}
+
+export default startEdit

--- a/src/Pages/Me/MeStoriesDraft.js
+++ b/src/Pages/Me/MeStoriesDraft.js
@@ -1,7 +1,50 @@
 import MeStories from "../../Components/MeStories"
+import { useEffect, useState } from "react"
+import { useCookies } from "react-cookie"
+import { useHistory } from "react-router-dom"
+import getCurrentUser from "../Main/Functions/getCurrentUser"
+import onClickSearchButton from "../Main/Functions/onClickSearchButton"
+import onChangeSearchbox from "../Main/Functions/onChangeSearchbox"
+import search from "../Main/Functions/search"
+import logout from "../Main/Functions/logout"
 
 const MeStiresDraft = () => {
-  return <MeStories />
+  const [cookie, , removeCookie] = useCookies(["auth"])
+  const token = cookie.auth
+  const history = useHistory()
+  if (token === "" || token === undefined) {
+    history.push("/")
+  }
+  // states
+  // user
+  const [user, setUser] = useState({})
+  // 헤더의 검색창이 열려있는지 닫혀있는지
+  const [isSearchboxOpen, setIsSearchboxOpen] = useState(false)
+  // 검색창의 value
+  const [searchValue, setSearchValue] = useState("")
+  // Dropdown 표시 여부
+  const [isDropdownOpened, setIsDropdownOpened] = useState(false)
+
+  useEffect(() => {
+    getCurrentUser(token, setUser)
+  }, [token])
+
+  return (
+    <MeStories
+      user={user}
+      isDropdownOpened={isDropdownOpened}
+      openDropdown={() => setIsDropdownOpened(true)}
+      hideDropdown={() => setIsDropdownOpened(false)}
+      isSearchboxOpen={isSearchboxOpen}
+      onClickSearchButton={() =>
+        onClickSearchButton(isSearchboxOpen, setIsSearchboxOpen, history)
+      }
+      onChangeSearchbox={(event) => onChangeSearchbox(event, setSearchValue)}
+      search={(event) => search(event, searchValue, history)}
+      signOut={() => logout(token, removeCookie)}
+      history={history}
+    />
+  )
 }
 
 export default MeStiresDraft

--- a/src/Pages/Me/MeStoriesDraft.js
+++ b/src/Pages/Me/MeStoriesDraft.js
@@ -1,5 +1,5 @@
 import MeStories from "../../Components/MeStories"
-import { useEffect, useState } from "react"
+import { useEffect, useState, useRef, useCallback } from "react"
 import { useCookies } from "react-cookie"
 import { useHistory, useLocation } from "react-router-dom"
 import getCurrentUser from "../Main/Functions/getCurrentUser"
@@ -7,12 +7,14 @@ import onClickSearchButton from "../Main/Functions/onClickSearchButton"
 import onChangeSearchbox from "../Main/Functions/onChangeSearchbox"
 import search from "../Main/Functions/search"
 import logout from "../Main/Functions/logout"
+import useIntersectionObserver from "../Search/Functions/useIntersectionObserver"
+import fetchStories from "./Functions/fetchStories"
 
 const MeStiresDraft = () => {
   const [cookie, , removeCookie] = useCookies(["auth"])
   const token = cookie.auth
   const history = useHistory()
-  const type = useLocation().pathname.split("/")[2]
+  const type = useLocation().pathname.split("/")[3]
   // drafts | public
 
   if (token === "" || token === undefined) {
@@ -28,27 +30,64 @@ const MeStiresDraft = () => {
   const [searchValue, setSearchValue] = useState("")
   // Dropdown 표시 여부
   const [isDropdownOpened, setIsDropdownOpened] = useState(false)
+  // my story list
+  const [stories, setStories] = useState([])
+  // request state
+  const [fetching, setFetching] = useState(false)
+  // check current page is end
+  const [isEnd, setIsEnd] = useState(false)
+
+  // refs
+  // 현재 검색된 마지막 페이지
+  const page = useRef(1)
+  // target
+  const targetRef = useRef(null)
 
   useEffect(() => {
     getCurrentUser(token, setUser)
-  }, [token])
+    fetchStories(token, type, setStories, setIsEnd)
+  }, [token, type])
+
+  // 다음 페이지 로드
+  const loadNextPage = useCallback(async () => {
+    if (stories.length > 0) {
+      setFetching(true)
+      page.current++
+      await fetchStories(token, type, setStories, setIsEnd, page)
+      setFetching(false)
+    }
+  }, [stories, token, type])
+
+  // 스크롤이 끝에 닿으면 다음 페이지 요청
+  useIntersectionObserver({
+    target: targetRef.current,
+    onIntersect: ([{ isIntersecting }]) => {
+      if (isIntersecting && !fetching && !isEnd) {
+        loadNextPage()
+      }
+    },
+  })
 
   return (
-    <MeStories
-      type={type}
-      user={user}
-      isDropdownOpened={isDropdownOpened}
-      openDropdown={() => setIsDropdownOpened(true)}
-      hideDropdown={() => setIsDropdownOpened(false)}
-      isSearchboxOpen={isSearchboxOpen}
-      onClickSearchButton={() =>
-        onClickSearchButton(isSearchboxOpen, setIsSearchboxOpen, history)
-      }
-      onChangeSearchbox={(event) => onChangeSearchbox(event, setSearchValue)}
-      search={(event) => search(event, searchValue, history)}
-      signOut={() => logout(token, removeCookie)}
-      history={history}
-    />
+    <div>
+      <MeStories
+        type={type}
+        user={user}
+        isDropdownOpened={isDropdownOpened}
+        openDropdown={() => setIsDropdownOpened(true)}
+        hideDropdown={() => setIsDropdownOpened(false)}
+        isSearchboxOpen={isSearchboxOpen}
+        onClickSearchButton={() =>
+          onClickSearchButton(isSearchboxOpen, setIsSearchboxOpen, history)
+        }
+        onChangeSearchbox={(event) => onChangeSearchbox(event, setSearchValue)}
+        search={(event) => search(event, searchValue, history)}
+        signOut={() => logout(token, removeCookie)}
+        history={history}
+        stories={stories}
+      />
+      <div ref={targetRef} />
+    </div>
   )
 }
 

--- a/src/Pages/Me/MeStoriesDraft.js
+++ b/src/Pages/Me/MeStoriesDraft.js
@@ -1,7 +1,7 @@
 import MeStories from "../../Components/MeStories"
 import { useEffect, useState } from "react"
 import { useCookies } from "react-cookie"
-import { useHistory } from "react-router-dom"
+import { useHistory, useLocation } from "react-router-dom"
 import getCurrentUser from "../Main/Functions/getCurrentUser"
 import onClickSearchButton from "../Main/Functions/onClickSearchButton"
 import onChangeSearchbox from "../Main/Functions/onChangeSearchbox"
@@ -12,7 +12,11 @@ const MeStiresDraft = () => {
   const [cookie, , removeCookie] = useCookies(["auth"])
   const token = cookie.auth
   const history = useHistory()
+  const type = useLocation().pathname.split("/")[2]
+  // drafts | public
+
   if (token === "" || token === undefined) {
+    // 로그인 하지 않았으면 main page로 redirect
     history.push("/")
   }
   // states
@@ -31,6 +35,7 @@ const MeStiresDraft = () => {
 
   return (
     <MeStories
+      type={type}
       user={user}
       isDropdownOpened={isDropdownOpened}
       openDropdown={() => setIsDropdownOpened(true)}

--- a/src/Pages/Me/MeStoriesDraft.js
+++ b/src/Pages/Me/MeStoriesDraft.js
@@ -1,7 +1,7 @@
 import MeStories from "../../Components/MeStories"
 
-const MeStoriesPage = () => {
+const MeStiresDraft = () => {
   return <MeStories />
 }
 
-export default MeStoriesPage
+export default MeStiresDraft

--- a/src/Pages/Me/MeStoriesPage.js
+++ b/src/Pages/Me/MeStoriesPage.js
@@ -9,6 +9,8 @@ import search from "../Main/Functions/search"
 import logout from "../Main/Functions/logout"
 import useIntersectionObserver from "../Search/Functions/useIntersectionObserver"
 import fetchStories from "./Functions/fetchStories"
+import deleteStory from "./Functions/deleteStory"
+import openActionButton from "./Functions/openActionButton"
 
 const MeStoriesPage = () => {
   const [cookie, , removeCookie] = useCookies(["auth"])
@@ -36,6 +38,10 @@ const MeStoriesPage = () => {
   const [fetching, setFetching] = useState(false)
   // check current page is end
   const [isEnd, setIsEnd] = useState(false)
+  // Action Menu가 열려있는지
+  const [isActionButtonOpen, setIsActionButtonOpen] = useState(false)
+  // action button을 눌렀을 때 버튼이 포함된 story id
+  const [selectedStoryId, setSelectedStoryId] = useState(-1)
 
   // refs
   // 현재 검색된 마지막 페이지
@@ -85,6 +91,17 @@ const MeStoriesPage = () => {
         signOut={() => logout(token, removeCookie)}
         history={history}
         stories={stories}
+        openActionButton={(id) => {
+          openActionButton(setIsActionButtonOpen, setSelectedStoryId, id)
+        }}
+        closeActionButton={() => {
+          setIsActionButtonOpen(false)
+        }}
+        isActionButtonOpen={isActionButtonOpen}
+        deleteStory={() => {
+          deleteStory(token, selectedStoryId)
+        }}
+        selectedStoryId={selectedStoryId}
       />
       <div ref={targetRef} />
     </div>

--- a/src/Pages/Me/MeStoriesPage.js
+++ b/src/Pages/Me/MeStoriesPage.js
@@ -1,0 +1,7 @@
+import MeStories from "../../Components/MeStories"
+
+const MeStoriesPage = () => {
+  return <MeStories />
+}
+
+export default MeStoriesPage

--- a/src/Pages/Me/MeStoriesPage.js
+++ b/src/Pages/Me/MeStoriesPage.js
@@ -11,6 +11,7 @@ import useIntersectionObserver from "../Search/Functions/useIntersectionObserver
 import fetchStories from "./Functions/fetchStories"
 import deleteStory from "./Functions/deleteStory"
 import openActionButton from "./Functions/openActionButton"
+import startEdit from "./Functions/startEdit"
 
 const MeStoriesPage = () => {
   const [cookie, , removeCookie] = useCookies(["auth"])
@@ -102,6 +103,9 @@ const MeStoriesPage = () => {
           deleteStory(token, selectedStoryId)
         }}
         selectedStoryId={selectedStoryId}
+        startEdit={() => {
+          startEdit(token, type, selectedStoryId, history)
+        }}
       />
       <div ref={targetRef} />
     </div>

--- a/src/Pages/Me/MeStoriesPage.js
+++ b/src/Pages/Me/MeStoriesPage.js
@@ -91,8 +91,8 @@ const MeStoriesPage = () => {
         signOut={() => logout(token, removeCookie)}
         history={history}
         stories={stories}
-        openActionButton={(id) => {
-          openActionButton(setIsActionButtonOpen, setSelectedStoryId, id)
+        openActionButton={(event, id) => {
+          openActionButton(event, setIsActionButtonOpen, setSelectedStoryId, id)
         }}
         closeActionButton={() => {
           setIsActionButtonOpen(false)

--- a/src/Pages/Me/MeStoriesPage.js
+++ b/src/Pages/Me/MeStoriesPage.js
@@ -10,7 +10,7 @@ import logout from "../Main/Functions/logout"
 import useIntersectionObserver from "../Search/Functions/useIntersectionObserver"
 import fetchStories from "./Functions/fetchStories"
 
-const MeStiresDraft = () => {
+const MeStoriesPage = () => {
   const [cookie, , removeCookie] = useCookies(["auth"])
   const token = cookie.auth
   const history = useHistory()
@@ -91,4 +91,4 @@ const MeStiresDraft = () => {
   )
 }
 
-export default MeStiresDraft
+export default MeStoriesPage

--- a/src/Pages/Me/MeStoriesPage.js
+++ b/src/Pages/Me/MeStoriesPage.js
@@ -43,6 +43,8 @@ const MeStoriesPage = () => {
   const [isActionButtonOpen, setIsActionButtonOpen] = useState(false)
   // action button을 눌렀을 때 버튼이 포함된 story id
   const [selectedStoryId, setSelectedStoryId] = useState(-1)
+  // confirm Modal
+  const [showConfirmModal, setShowConfirmModal] = useState(false)
 
   // refs
   // 현재 검색된 마지막 페이지
@@ -106,6 +108,9 @@ const MeStoriesPage = () => {
         startEdit={() => {
           startEdit(token, type, selectedStoryId, history)
         }}
+        showConfirmModal={showConfirmModal}
+        openConfirmModal={() => setShowConfirmModal(true)}
+        hideConfirmModal={() => setShowConfirmModal(false)}
       />
       <div ref={targetRef} />
     </div>

--- a/src/Pages/Me/MeStoriesPage.js
+++ b/src/Pages/Me/MeStoriesPage.js
@@ -62,7 +62,7 @@ const MeStoriesPage = () => {
     if (stories.length > 0) {
       setFetching(true)
       page.current++
-      await fetchStories(token, type, setStories, setIsEnd, page)
+      await fetchStories(token, type, setStories, setIsEnd, page.current)
       setFetching(false)
     }
   }, [stories, token, type])

--- a/src/Pages/Me/MeStoriesPublish.js
+++ b/src/Pages/Me/MeStoriesPublish.js
@@ -1,0 +1,7 @@
+import MeStories from "../../Components/MeStories"
+
+const MeStiresPublish = () => {
+  return <MeStories />
+}
+
+export default MeStiresPublish

--- a/src/Pages/Me/MeStoriesPublish.js
+++ b/src/Pages/Me/MeStoriesPublish.js
@@ -1,7 +1,0 @@
-import MeStories from "../../Components/MeStories"
-
-const MeStiresPublish = () => {
-  return <MeStories />
-}
-
-export default MeStiresPublish

--- a/src/Pages/Me/Routes.js
+++ b/src/Pages/Me/Routes.js
@@ -1,8 +1,8 @@
-import MeStoriesDraft from "./MeStoriesDraft"
+import MeStoriesPage from "./MeStoriesPage"
 
 const routes = {
-  drafts: { path: "/me/stories/drafts", component: MeStoriesDraft },
-  public: { path: "/me/stories/public", component: MeStoriesDraft },
+  drafts: { path: "/me/stories/drafts", component: MeStoriesPage },
+  public: { path: "/me/stories/public", component: MeStoriesPage },
 }
 
 export { routes }

--- a/src/Pages/Me/Routes.js
+++ b/src/Pages/Me/Routes.js
@@ -1,9 +1,8 @@
 import MeStoriesDraft from "./MeStoriesDraft"
-import MeStoriesPublish from "./MeStoriesPublish"
 
 const routes = {
-  draft: { path: "/me/stories/drafts", component: MeStoriesDraft },
-  publish: { path: "/me/stories/public", component: MeStoriesPublish },
+  drafts: { path: "/me/stories/drafts", component: MeStoriesDraft },
+  public: { path: "/me/stories/public", component: MeStoriesDraft },
 }
 
 export { routes }

--- a/src/Pages/Me/Routes.js
+++ b/src/Pages/Me/Routes.js
@@ -1,0 +1,7 @@
+import MeStoriesPage from "./MeStoriesPage"
+
+const routes = {
+  stories: { path: "/me/stories", component: MeStoriesPage },
+}
+
+export { routes }

--- a/src/Pages/Me/Routes.js
+++ b/src/Pages/Me/Routes.js
@@ -1,7 +1,9 @@
-import MeStoriesPage from "./MeStoriesPage"
+import MeStoriesDraft from "./MeStoriesDraft"
+import MeStoriesPublish from "./MeStoriesPublish"
 
 const routes = {
-  stories: { path: "/me/stories", component: MeStoriesPage },
+  draft: { path: "/me/stories/drafts", component: MeStoriesDraft },
+  publish: { path: "/me/stories/public", component: MeStoriesPublish },
 }
 
 export { routes }

--- a/src/Pages/Me/index.js
+++ b/src/Pages/Me/index.js
@@ -1,5 +1,5 @@
 import { routes } from "./Routes"
-import { Switch, Route } from "react-router-dom"
+import { Switch, Route, Redirect } from "react-router-dom"
 
 const MePage = () => {
   return (
@@ -9,6 +9,7 @@ const MePage = () => {
         path={routes.stories.path}
         component={routes.stories.component}
       />
+      <Redirect to={routes.stories.path} />
     </Switch>
   )
 }

--- a/src/Pages/Me/index.js
+++ b/src/Pages/Me/index.js
@@ -1,0 +1,16 @@
+import { routes } from "./Routes"
+import { Switch, Route } from "react-router-dom"
+
+const MePage = () => {
+  return (
+    <Switch>
+      <Route
+        exact
+        path={routes.stories.path}
+        component={routes.stories.component}
+      />
+    </Switch>
+  )
+}
+
+export default MePage

--- a/src/Pages/Me/index.js
+++ b/src/Pages/Me/index.js
@@ -6,10 +6,15 @@ const MePage = () => {
     <Switch>
       <Route
         exact
-        path={routes.stories.path}
-        component={routes.stories.component}
+        path={routes.draft.path}
+        component={routes.draft.component}
       />
-      <Redirect to={routes.stories.path} />
+      <Route
+        exact
+        path={routes.publish.path}
+        component={routes.publish.component}
+      />
+      <Redirect to={routes.draft.path} />
     </Switch>
   )
 }

--- a/src/Pages/Me/index.js
+++ b/src/Pages/Me/index.js
@@ -6,15 +6,15 @@ const MePage = () => {
     <Switch>
       <Route
         exact
-        path={routes.draft.path}
-        component={routes.draft.component}
+        path={routes.drafts.path}
+        component={routes.drafts.component}
       />
       <Route
         exact
-        path={routes.publish.path}
-        component={routes.publish.component}
+        path={routes.public.path}
+        component={routes.public.component}
       />
-      <Redirect to={routes.draft.path} />
+      <Redirect to={routes.drafts.path} />
     </Switch>
   )
 }

--- a/src/Pages/Search/Functions/fetchStories.js
+++ b/src/Pages/Search/Functions/fetchStories.js
@@ -2,7 +2,6 @@ import { getStory } from "../../../api"
 
 const fetchStories = async (searchWord, setStories, setIsEnd, page = 1) => {
   // story 검색 결과를 패치
-  console.log(page)
   try {
     const response = await getStory({ page, title: searchWord })
     setStories((stories) => {

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -3,6 +3,7 @@ import EditPage from "./Pages/Edit"
 import CallbackPage from "./Pages/Callback"
 import StoryPage from "./Pages/Story/Story"
 import SearchPage from "./Pages/Search"
+import MePage from "./Pages/Me"
 
 const routes = {
   main: { path: "/main", component: MainPage },
@@ -10,5 +11,6 @@ const routes = {
   story: { path: "/story/:story_id", component: StoryPage },
   callback: { path: "/callback", component: CallbackPage },
   search: { path: "/search", component: SearchPage },
+  me: { path: "/me", component: MePage },
 }
 export { routes }

--- a/src/api.js
+++ b/src/api.js
@@ -19,6 +19,13 @@ export const getUserMeAbout = async (token) => {
   return response
 }
 
+export const getUserMeStory = async (token, publish) => {
+  // GET /user/me/story/?publish=[true|false]
+  const config = { headers: { Authorization: "Token " + token } }
+  const response = await axios.get("user/me/story/?publish=" + publish, config)
+  return response
+}
+
 export const postUser = async (body) => {
   // POST /user/
   const response = await axios.post("user/", body)

--- a/src/api.js
+++ b/src/api.js
@@ -132,3 +132,10 @@ export const getStory = async ({ page, title, tag }) => {
   const response = await axios.get("story/" + queryString)
   return response
 }
+
+export const deleteStoryStoryId = async (token, id) => {
+  // DELETE /story/{story_id}
+  const config = { headers: { Authorization: "Token " + token } }
+  const response = await axios.delete("story/" + id + "/", config)
+  return response
+}

--- a/src/api.js
+++ b/src/api.js
@@ -19,10 +19,13 @@ export const getUserMeAbout = async (token) => {
   return response
 }
 
-export const getUserMeStory = async (token, publish) => {
-  // GET /user/me/story/?publish=[true|false]
+export const getUserMeStory = async (token, publish, page) => {
+  // GET /user/me/story/?publish=[true|false]&page={page}
   const config = { headers: { Authorization: "Token " + token } }
-  const response = await axios.get("user/me/story/?publish=" + publish, config)
+  const response = await axios.get(
+    "user/me/story/?public=" + publish + "&page=" + page,
+    config
+  )
   return response
 }
 

--- a/src/api.js
+++ b/src/api.js
@@ -133,6 +133,12 @@ export const getStory = async ({ page, title, tag }) => {
   return response
 }
 
+export const getStoryById = async (storyid) => {
+  //GET /story/{story_id}
+  const response = await axios.get("story/" + storyid)
+  return response
+}
+
 export const deleteStoryStoryId = async (token, id) => {
   // DELETE /story/{story_id}
   const config = { headers: { Authorization: "Token " + token } }

--- a/src/api.js
+++ b/src/api.js
@@ -1,8 +1,8 @@
 import axios from "axios"
 
 // set base url
-const baseUrl = "http://localhost:8000/"
-// const baseUrl = "https://api.wadium.shop/"
+// const baseUrl = "http://localhost:8000/"
+const baseUrl = "https://api.wadium.shop/"
 axios.defaults.baseURL = baseUrl
 
 // user api


### PR DESCRIPTION
### 변경 사항
- 자신의 글 보는 페이지 추가
- draft/published 구분해서 보여줌
- 무한 스크롤 구현
- 수정 버튼 누를 시 draft는 /edit/{story_id}로 보냄
- published는 같은 내용으로 POST 요청을 보낸 후 받은 새로운 id로 이동.
- 삭제 버튼 누를 시 confirm modal 띄운 후 한번 더 삭제 누르면 최종 삭제 후 페이지 리로드

원래  수정을 하려면 기존 글이 보여야 하나, 현재 GET /story/{story_id}/ api가 draft인 글은 허용되지 않아 보이지 않습니다. 백엔드 수정 이후 잘 작동될 예정입니다.
이미 publish 된 글을 수정하면 기존 글을 바로 수정하는 것이 아니라 draft 상태의 같은 내용의 새로운 글을 생성한 이후 그 글을 수정합니다. 이러면 최종적으로 publish가 두 개가 되는 일이 발생할 수 있는 문제점이 있습니다만, 원래 글의 publish를 취소하고 수정해버리면 만약 수정을 취소하고 싶을 경우 돌이킬 수 없기 때문에 이렇게 하였습니다.